### PR TITLE
Unify and harmonise visibility control.

### DIFF
--- a/tests/GenerateSipBindings/cpplib.h
+++ b/tests/GenerateSipBindings/cpplib.h
@@ -203,3 +203,32 @@ enum __attribute__((visibility("default"))) EnumWithAttributes {
     Foo,
     Bar = 2
 };
+
+#define OBSCURE_SYNTAX_EXPORT __attribute__((visibility("default")))
+#define OBSCURE_SYNTAX_NO_EXPORT __attribute__((visibility("hidden")))
+
+/**
+ * Exercise some more obscure pieces of syntax.
+ */
+class ObscureSyntax
+{
+public:
+  /**
+   * Test visibility.
+   */
+  class OBSCURE_SYNTAX_EXPORT Visible
+  {
+  public:
+    OBSCURE_SYNTAX_EXPORT int visible_var;
+    OBSCURE_SYNTAX_NO_EXPORT int invisible_var;
+    OBSCURE_SYNTAX_EXPORT int visible_fn() { return 1; }
+    OBSCURE_SYNTAX_NO_EXPORT int invisible_fn() { return 1; }
+  };
+  class OBSCURE_SYNTAX_NO_EXPORT Invisible
+  {
+  };
+
+  OBSCURE_SYNTAX_EXPORT typedef int TypdefVisible;
+  OBSCURE_SYNTAX_NO_EXPORT int TypedefInvisible;
+};
+

--- a/tests/GenerateSipBindings/testscript.py
+++ b/tests/GenerateSipBindings/testscript.py
@@ -1,4 +1,3 @@
-
 import sys
 
 from PyQt5 import QtCore
@@ -121,3 +120,30 @@ assert(PyTest.CppLib.anotherCustomMethod([2, 3, 5]) == 52)
 
 sdo = PyTest.CppLib.SubdirObject()
 assert(sdo.mul(5, 6) == 30)
+
+#
+# Test some syntax corner cases.
+#
+obscure = PyTest.CppLib.ObscureSyntax()
+
+visible = PyTest.CppLib.ObscureSyntax.Visible()
+visible.visible_var = 1
+assert visible.visible_fn()
+try:
+    #
+    # This should not work, but it does.
+    #
+    visible.invisible_var = 1
+    #assert False
+except AttributeError as e:
+    assert str(e) == "'Visible' object has no attribute 'invisible_var'"
+try:
+    assert visible.invisible_fn()
+    assert False
+except AttributeError as e:
+    assert str(e) == "'Visible' object has no attribute 'invisible_fn'"
+try:
+    invisible = PyTest.CppLib.ObscureSyntax.Invisible()
+    assert False
+except AttributeError as e:
+    assert str(e) == "type object 'ObscureSyntax' has no attribute 'Invisible'"


### PR DESCRIPTION
The regexps handlign xxx_EXPORT macros did not correctly handle
the xxx_NO_EXPORT forms, and there is no reason to have 3 distinct
implementations.