### PR TITLE
Rule database structure changes, and related diagnostic/doc changes.

### DIFF
--- a/find-modules/Qt5Ruleset.py
+++ b/find-modules/Qt5Ruleset.py
@@ -116,41 +116,7 @@ class RuleSet(rules_engine.RuleSet):
     and regular expression-based matching rules.
     """
     def __init__(self):
-        self._container_db = rules_engine.ContainerRuleDb(container_rules)
-        self._forward_declaration_db = rules_engine.ForwardDeclarationRuleDb(forward_declaration_rules)
-        self._fn_db = rules_engine.FunctionRuleDb(function_rules)
-        self._param_db = rules_engine.ParameterRuleDb(parameter_rules)
-        self._typedef_db = rules_engine.TypedefRuleDb(typedef_rules)
-        self._var_db = rules_engine.VariableRuleDb(variable_rules)
-        self._methodcode = rules_engine.MethodCodeDb({})
-        self._modulecode = rules_engine.ModuleCodeDb({})
-
-    def container_rules(self):
-        return self._container_db
-
-    def forward_declaration_rules(self):
-        return self._forward_declaration_db
-
-    def function_rules(self):
-        return self._fn_db
-
-    def parameter_rules(self):
-        return self._param_db
-
-    def typedef_rules(self):
-        return self._typedef_db
-
-    def variable_rules(self):
-        return self._var_db
-
-    def methodcode_rules(self):
-        return self._methodcode
-
-    def modulecode_rules(self):
-        return self._modulecode
-
-    def methodcode(self, function, sip):
-        return self._methodcode.apply(function, sip)
-
-    def modulecode(self, filename, sip):
-        return self._modulecode.apply(filename, sip)
+        super(RuleSet, self).__init__(
+            container_rules=container_rules, forward_declaration_rules=forward_declaration_rules,
+            function_rules=function_rules, parameter_rules=parameter_rules, typedef_rules=typedef_rules,
+            variable_rules=variable_rules)

--- a/find-modules/rules_engine.py
+++ b/find-modules/rules_engine.py
@@ -30,8 +30,7 @@
 """SIP file generation rules engine."""
 
 from __future__ import print_function
-
-from abc import *
+from abc import ABCMeta, abstractmethod
 import argparse
 import gettext
 import inspect
@@ -72,13 +71,8 @@ def _parents(container):
 
 
 class Rule(object):
-    def __init__(self, db, rule_number, fn, pattern_zip):
-        #
-        # Derive a useful name for diagnostic purposes.
-        #
-        caller = os.path.basename(inspect.stack()[3][1])
-        self.name =  "{}:{}[{}],{}".format(caller, type(db).__name__, rule_number, fn.__name__)
-        self.rule_number = rule_number
+    def __init__(self, rule_name, fn, pattern_zip):
+        self.name =  "{},{}".format(rule_name, fn.__name__)
         self.fn = fn
         self.usage = 0
         try:
@@ -124,7 +118,8 @@ class Rule(object):
             if delta:
                 logger.debug(_("Rule {} modified {}, {}->{}").format(self, fqn, original, modified))
             else:
-                logger.warn(_("Rule {} did not modify {}, {}").format(self, fqn, original))
+                if self.fn is not noop:
+                    logger.warn(_("Rule {} did not modify {}, {}").format(self, fqn, original))
                 return None
         return self
 
@@ -135,15 +130,28 @@ class Rule(object):
 class AbstractCompiledRuleDb(object):
     __metaclass__ = ABCMeta
 
-    def __init__(self, db, parameter_names):
-        self.db = db
+    def __init__(self, raw_rules, parameter_names):
+        """
+        Create a database of compiled rules.
+
+        :param raw_rules:   A function which returns an ordered list of raw rules. The point of
+                            using a function is that a function has a name which can be used for
+                            diagnostics.
+        :parameter_names:   The name of each field in the raw rules.
+        """
         self.compiled_rules = []
-        for i, raw_rule in enumerate(db()):
-            if len(raw_rule) != len(parameter_names) + 1:
-                raise RuntimeError(_("Bad raw rule {}: {}: {}").format(db.__name__, raw_rule, parameter_names))
-            z = zip(raw_rule[:-1], parameter_names)
-            self.compiled_rules.append(Rule(self, i, raw_rule[-1], z))
+        self.parameter_names = parameter_names
         self.candidate_formatter = _SEPARATOR.join(["{}"] * len(parameter_names))
+        #
+        # Backwards compatibility.
+        #
+        # TODO: Remove when Steve and Shaheed are agreed/ready.
+        #
+        if not callable(raw_rules):
+            tmp = lambda: raw_rules
+            self.add_rules(tmp)
+        else:
+            self.add_rules(raw_rules)
 
     def _match(self, *args):
         candidate = self.candidate_formatter.format(*args)
@@ -156,6 +164,48 @@ class AbstractCompiledRuleDb(object):
                 rule.usage += 1
                 return matcher, rule
         return None, None
+
+    def add_rules(self, raw_rules):
+        """
+        Add to the existing set of rules. The new rules have precedence over existing rules.
+
+        :param raw_rules:   A function which returns an ordered list of raw rules. The point of
+                            using a function is that a function has a name which can be used for
+                            diagnostics. May be None.
+        """
+        if raw_rules is None or raw_rules() is None:
+            return
+        file_ = inspect.getfile(raw_rules)
+        if file_ in [__file__, __file__[:-1]]:
+            #
+            # We must have come through the backwards compatibility in __init__.
+            #
+            # TODO: Remove when Steve and Shaheed are agreed/ready.
+            #
+            file_ = inspect.stack()[4][1]
+            name_ = str(inspect.stack()[4][2])
+        else:
+            name_ = raw_rules.__name__
+        file_ = os.path.basename(file_)
+        tmp = []
+        for i, raw_rule in enumerate(raw_rules()):
+            #
+            # Derive a useful name for diagnostic purposes.
+            #
+            rule_name = "{}:{}[{}]".format(file_, name_, i)
+            #
+            # Backwards compatibility. Older rule databases will be missing entries for (fn_result, decl) and
+            # (prefix, suffix) for TypedefRuleDb and FunctionRuleDb respectively.
+            #
+            # TODO: Remove when Steve and Shaheed are agreed/ready.
+            #
+            if len(raw_rule) == len(self.parameter_names) - 1 and isinstance(self, (TypedefRuleDb, FunctionRuleDb)):
+                raw_rule = raw_rule[:-1] + [".*", ".*"] + [raw_rule[-1]]
+            if len(raw_rule) != len(self.parameter_names) + 1:
+                raise RuntimeError(_("Bad raw rule {}: {}: {}").format(rule_name, raw_rule, self.parameter_names))
+            z = zip(raw_rule[:-1], self.parameter_names)
+            tmp.append(Rule(rule_name, raw_rule[-1], z))
+        self.compiled_rules = tmp + self.compiled_rules
 
     @abstractmethod
     def apply(self, *args):
@@ -596,16 +646,63 @@ class VariableRuleDb(AbstractCompiledRuleDb):
 class AbstractCompiledCodeDb(object):
     __metaclass__ = ABCMeta
 
-    def __init__(self, db):
-        caller = os.path.basename(inspect.stack()[2][1])
-        self.name = "{}:{}".format(caller, type(self).__name__)
-        self.db = db
+    def __init__(self, raw_rules):
+        """
+        Create a database of compiled rules.
+
+        :param raw_rules:   A dict of raw rules, or a function which returns a dict of raw rules.
+                            The point of using a function is that a function has a name which can
+                            be used for diagnostics.
+        """
+        self.compiled_rules = {}
+        self.names = []
+        #
+        # Backwards compatibility.
+        #
+        # TODO: Remove when Steve and Shaheed are agreed/ready.
+        #
+        if not callable(raw_rules):
+            tmp = lambda: raw_rules
+            self.add_rules(tmp)
+        else:
+            self.add_rules(raw_rules)
+
+    def add_rules(self, raw_rules):
+        """
+        Add to the existing set of rules. The new rules have precedence over existing rules.
+
+        :param raw_rules:   A function which returns a dict of raw rules. The point of using a
+                            function is that a function has a name which can be used for
+                            diagnostics. May be None.
+        """
+        if raw_rules is None or raw_rules() is None:
+            return
+        file_ = inspect.getfile(raw_rules)
+        if file_ in [__file__, __file__[:-1]]:
+            #
+            # We must have come through the backwards compatibility in __init__.
+            #
+            # TODO: Remove when Steve and Shaheed are agreed/ready.
+            #
+            file_ = inspect.stack()[4][1]
+            name_ = str(inspect.stack()[4][2])
+        else:
+            name_ = raw_rules.__name__
+        file_ = os.path.basename(file_)
+        #
+        # Derive a useful name for diagnostic purposes.
+        #
+        self.names.append("{}:{}".format(file_, name_))
+        for k, v in raw_rules().items():
+            if k in self.compiled_rules:
+                logger.debug(_("Updating raw rule {}").format(k))
+            self.compiled_rules[k] = v
 
     @abstractmethod
     def apply(self, function, sip):
         raise NotImplemented(_("Missing subclass"))
 
-    def trace_result(self, parents, item, original, modified):
+    def trace_result(self, rule, parents, item, original, modified):
         """
         Record any modification both in the log and the returned result. If a rule fired, but
         caused no modification, that is logged.
@@ -613,17 +710,18 @@ class AbstractCompiledCodeDb(object):
         :return: Modifying rule or None.
         """
         fqn = parents + "::" + original["name"] + "[" + str(item.extent.start.line) + "]"
-        self._trace_result(fqn, original, modified)
+        return self._trace_result(rule, fqn, original, modified)
 
-    def _trace_result(self, fqn, original, modified):
+    def _trace_result(self, rule, fqn, original, modified):
         """
         Record any modification both in the log and the returned result. If a rule fired, but
         caused no modification, that is logged.
 
         :return: Modifying rule or None.
         """
+        ruleset = self.names[rule["ruleset"]]
         if not modified["name"]:
-            logger.debug(_("Rule {} suppressed {}, {}").format(self, fqn, original))
+            logger.debug(_("Rule {} discarded {}, {}").format(ruleset, fqn, original))
         else:
             delta = False
             for k, v in original.iteritems():
@@ -631,18 +729,16 @@ class AbstractCompiledCodeDb(object):
                     delta = True
                     break
             if delta:
-                logger.debug(_("Rule {} modified {}, {}->{}").format(self, fqn, original, modified))
+                logger.debug(_("Rule {} modified {}, {}->{}").format(ruleset, fqn, original, modified))
             else:
-                logger.warn(_("Rule {} did not modify {}, {}").format(self, fqn, original))
+                logger.warn(_("Rule {} did not modify {}, {}").format(ruleset, fqn, original))
                 return None
-        return self
+        return ruleset
 
     @abstractmethod
     def dump_usage(self, fn):
         raise NotImplemented(_("Missing subclass"))
 
-    def __str__(self):
-        return self.name
 
 class MethodCodeDb(AbstractCompiledCodeDb):
     """
@@ -692,19 +788,28 @@ class MethodCodeDb(AbstractCompiledCodeDb):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, db):
-        super(MethodCodeDb, self).__init__(db)
+    def __init__(self, raw_rules):
+        super(MethodCodeDb, self).__init__(raw_rules)
 
-        for k, v in self.db.items():
+    def add_rules(self, raw_rules):
+        if raw_rules is None or raw_rules() is None:
+            return
+        super(MethodCodeDb, self).add_rules(raw_rules)
+        #
+        # Add a usage count and other diagnostic support for each item in the database.
+        #
+        ruleset = len(self.names) - 1
+        for k, v in raw_rules().items():
             for l in v.keys():
-                v[l]["usage"] = 0
+                self.compiled_rules[k][l]["usage"] = 0
+                self.compiled_rules[k][l]["ruleset"] = ruleset
 
     def _get(self, item, name):
         #
         # Lookup any parent-level entries.
         #
         parents = _parents(item)
-        entries = self.db.get(parents, None)
+        entries = self.compiled_rules.get(parents, None)
         if not entries:
             return None
         #
@@ -731,27 +836,29 @@ class MethodCodeDb(AbstractCompiledCodeDb):
             if callable(entry["code"]):
                 fn = entry["code"]
                 fn_file = os.path.basename(inspect.getfile(fn))
-                trace = "// Generated (by {}:{}): {}\n".format(fn_file, fn.__name__, {k:v for (k,v) in entry.items() if k != "code"})
+                trace = "// Generated for '{}:{}' (by {},{}:{}):\n".format(_parents(function), function.spelling, self.names[entry["ruleset"]], fn_file, fn.__name__)
                 fn(function, sip, entry)
             else:
-                trace = "// Inserted (by {}:{}): {}\n".format(_parents(function), function.spelling, {k:v for (k,v) in entry.items() if k != "code"})
+                trace = "// Inserted for '{}:{}' (by {}):\n".format(_parents(function), function.spelling, self.names[entry["ruleset"]])
                 sip["code"] = entry["code"]
                 sip["parameters"] = entry.get("parameters", sip["parameters"])
                 sip["fn_result"] = entry.get("fn_result", sip["fn_result"])
             #
             # Fetch/format the code.
             #
-            sip["code"] = trace + textwrap.dedent(sip["code"]).strip() + "\n"
-            return self.trace_result(_parents(function), function, before, sip)
+            sip["code"] = textwrap.dedent(sip["code"]).strip() + "\n"
+            sip["code"] = trace + sip["code"]
+            return self.trace_result(entry, _parents(function), function, before, sip)
         return None
 
     def dump_usage(self, fn):
         """ Dump the usage counts."""
-        for k in sorted(self.db.keys()):
-            vk = self.db[k]
+        for k in sorted(self.compiled_rules.keys()):
+            vk = self.compiled_rules[k]
             for l in sorted(vk.keys()):
                 vl = vk[l]
-                fn(str(self) + " for " + k + "," + l, vl["usage"])
+                fn(self.names[vl["ruleset"]] + " for " + k + "," + l, vl["usage"])
+
 
 class ModuleCodeDb(AbstractCompiledCodeDb):
     """
@@ -789,19 +896,26 @@ class ModuleCodeDb(AbstractCompiledCodeDb):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, db):
-        super(ModuleCodeDb, self).__init__(db)
+    def __init__(self, raw_rules):
+        super(ModuleCodeDb, self).__init__(raw_rules)
+
+    def add_rules(self, raw_rules):
+        if raw_rules is None or raw_rules() is None:
+            return
+        super(ModuleCodeDb, self).add_rules(raw_rules)
         #
         # Add a usage count and other diagnostic support for each item in the database.
         #
-        for k, v in self.db.items():
-            v["usage"] = 0
+        ruleset = len(self.names) - 1
+        for k, v in raw_rules().items():
+            self.compiled_rules[k]["usage"] = 0
+            self.compiled_rules[k]["ruleset"] = ruleset
 
     def _get(self, filename):
         #
         # Lookup for an actual hit.
         #
-        entry = self.db.get(filename, None)
+        entry = self.compiled_rules.get(filename, None)
         if not entry:
             return None
         entry["usage"] += 1
@@ -822,23 +936,26 @@ class ModuleCodeDb(AbstractCompiledCodeDb):
             if callable(entry["code"]):
                 fn = entry["code"]
                 fn_file = os.path.basename(inspect.getfile(fn))
-                trace = "\n// Generated (by {}:{}): {}".format(fn_file, fn.__name__, {k:v for (k,v) in entry.items() if k != "code"})
+                trace = "// Generated for '{}' (by {},{}:{}):\n".format(filename, self.names[entry["ruleset"]], fn_file, fn.__name__)
                 fn(filename, sip, entry)
-                sip["code"] = trace + sip["code"]
             else:
+                trace = "// Inserted for '{}' (by {}):\n".format(filename, self.names[entry["ruleset"]])
                 sip["code"] = entry["code"]
+                sip["decl"] = entry.get("decl", sip["decl"])
             #
             # Fetch/format the code.
             #
             sip["code"] = textwrap.dedent(sip["code"]).strip() + "\n"
-            fqn = filename + "::" + before["name"]
-            self._trace_result(fqn, before, sip)
+            sip["code"] = trace + sip["code"]
+            fqn = filename
+            return self._trace_result(entry, fqn, before, sip)
+        return None
 
     def dump_usage(self, fn):
         """ Dump the usage counts."""
-        for k in sorted(self.db.keys()):
-            v = self.db[k]
-            fn(str(self) + " for " + k, v["usage"])
+        for k in sorted(self.compiled_rules.keys()):
+            v = self.compiled_rules[k]
+            fn(self.names[v["ruleset"]] + " for " + k, v["usage"])
 
 
 class RuleSet(object):
@@ -850,113 +967,155 @@ class RuleSet(object):
     You then simply run the SIP generation and SIP compilation programs passing
     in the name of your rules file
     """
-    __metaclass__ = ABCMeta
+    def __init__(self, container_rules=None, forward_declaration_rules=None,
+                 function_rules=None, parameter_rules=None, typedef_rules=None,
+                 variable_rules=None, methodcode=None,
+                 modulecode=None):
+        self._container_db = ContainerRuleDb(container_rules)
+        self._forward_declaration_db = ForwardDeclarationRuleDb(forward_declaration_rules)
+        self._fn_db = FunctionRuleDb(function_rules)
+        self._param_db = ParameterRuleDb(parameter_rules)
+        self._typedef_db = TypedefRuleDb(typedef_rules)
+        self._var_db = VariableRuleDb(variable_rules)
+        self._methodcode = MethodCodeDb(methodcode)
+        self._modulecode = ModuleCodeDb(modulecode)
 
-    @abstractmethod
+    def add_rules(self, container_rules=None, forward_declaration_rules=None,
+                  function_rules=None, parameter_rules=None, typedef_rules=None,
+                  variable_rules=None, methodcode=None,
+                  modulecode=None):
+        self._container_db.add_rules(container_rules)
+        self._forward_declaration_db.add_rules(forward_declaration_rules),
+        self._fn_db.add_rules(function_rules)
+        self._param_db.add_rules(parameter_rules)
+        self._typedef_db.add_rules(typedef_rules)
+        self._var_db.add_rules(variable_rules)
+        self._methodcode.add_rules(methodcode)
+        self._modulecode.add_rules(modulecode)
+
     def container_rules(self):
         """
         Return a compiled list of rules for containers.
 
         :return: A ContainerRuleDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._container_db
 
-    @abstractmethod
     def forward_declaration_rules(self):
         """
         Return a compiled list of rules for containers.
 
         :return: A ForwardDeclarationRuleDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
 
-    @abstractmethod
+        return self._forward_declaration_db
+
     def function_rules(self):
         """
         Return a compiled list of rules for functions.
 
         :return: A FunctionRuleDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._fn_db
 
-    @abstractmethod
     def parameter_rules(self):
         """
         Return a compiled list of rules for function parameters.
 
         :return: A ParameterRuleDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._param_db
 
-    @abstractmethod
     def typedef_rules(self):
         """
         Return a compiled list of rules for typedefs.
 
         :return: A TypedefRuleDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._typedef_db
 
-    @abstractmethod
     def variable_rules(self):
         """
         Return a compiled list of rules for variables.
 
         :return: A VariableRuleDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._var_db
 
-    @abstractmethod
     def methodcode_rules(self):
         """
         Return a compiled list of rules for method-related code.
 
         :return: A MethodCodeDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._methodcode
 
-    @abstractmethod
     def modulecode_rules(self):
         """
         Return a compiled list of rules for module-related code.
 
         :return: A ModuleCodeDb instance
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._modulecode
 
-    def dump_unused(self):
-        """Usage statistics, to identify unused rules."""
-        def dumper(rule, usage):
-            if usage:
-                logger.info(_("Rule {} used {} times".format(rule, usage)))
-            else:
-                logger.warn(_("Rule {} was not used".format(rule)))
-
-        for db in [self.container_rules(), self.forward_declaration_rules(), self.function_rules(),
-                   self.parameter_rules(), self.typedef_rules(),
-                   self.variable_rules(), self.methodcode_rules(), self.modulecode_rules()]:
-            db.dump_usage(dumper)
-
-    @abstractmethod
-    def methodcode(self, container, function):
+    def methodcode(self, function, sip):
         """
         Lookup %MethodCode.
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._methodcode.apply(function, sip)
 
-    @abstractmethod
-    def modulecode(self, filename):
+    def modulecode(self, filename, sip):
         """
         Lookup %ModuleCode and friends.
         """
-        raise NotImplemented(_("Missing subclass implementation"))
+        return self._modulecode.apply(filename, sip)
+
+    def dump_unused(self, fn=None):
+        """
+        Usage statistics, to identify unused rules.
+
+        :param fn:                  An optional callback which takes (rule, usage_count) arguments.
+                                    By default, output will be to the logger.
+        """
+        def dumper(rule, usage_count):
+            if usage_count:
+                logger.info(_("Rule {} used {} times".format(rule, usage_count)))
+            else:
+                logger.warn(_("Rule {} was not used".format(rule)))
+
+        if fn == None:
+            fn = dumper
+        for db in [self.container_rules(), self.forward_declaration_rules(), self.function_rules(),
+                    self.parameter_rules(), self.typedef_rules(), self.variable_rules(),
+                    self.methodcode_rules(), self.modulecode_rules()]:
+            db.dump_usage(fn)
+
+
+#
+# Some common rule actions, as a convenience for rule writers.
+#
+def noop(*args):
+    """
+    This action function "does nothing" but without causing a warning.
+    """
+    pass
 
 
 def container_discard(container, sip, matcher):
     sip["name"] = ""
 
+
 def function_discard(container, function, sip, matcher):
     sip["name"] = ""
+
+
+def typedef_discard(container, typedef, sip, matcher):
+    sip["name"] = ""
+
+
+def variable_discard(container, variable, sip, matcher):
+    sip["name"] = ""
+
 
 def parameter_transfer_to_parent(container, function, parameter, sip, matcher):
     if function.is_static_method():
@@ -964,33 +1123,35 @@ def parameter_transfer_to_parent(container, function, parameter, sip, matcher):
     else:
         sip["annotations"].add("TransferThis")
 
+
 def param_rewrite_mode_t_as_int(container, function, parameter, sip, matcher):
     sip["decl"] = sip["decl"].replace("mode_t", "unsigned int")
+
 
 def return_rewrite_mode_t_as_int(container, function, sip, matcher):
     sip["fn_result"] = "unsigned int"
 
-def variable_discard(container, variable, sip, matcher):
-    sip["name"] = ""
 
 def parameter_strip_class_enum(container, function, parameter, sip, matcher):
     sip["decl"] = sip["decl"].replace("class ", "").replace("enum ", "")
+
 
 def function_discard_impl(container, function, sip, matcher):
     if function.extent.start.column == 1:
         sip["name"] = ""
 
-def typedef_discard(container, typedef, sip, matcher):
-    sip["name"] = ""
 
 def discard_QSharedData_base(container, sip, matcher):
     sip["base_specifiers"].remove("QSharedData")
 
+
 def mark_forward_declaration_external(container, sip, matcher):
     sip["annotations"].add("External")
 
+
 def container_mark_abstract(container, sip, matcher):
     sip["annotations"].add("Abstract")
+
 
 def rules(project_rules):
     """
@@ -998,9 +1159,57 @@ def rules(project_rules):
 
     :param project_rules:       The rules file for the project.
     """
-    import imp
-    imp.load_source("project_rules", project_rules)
+    try:
+        import imp
+        imp.load_source("project_rules", project_rules)
+    except ImportError:
+        if sys.version_info.major == 2:
+            raise
+        import importlib
+        spec = importlib.util.spec_from_file_location("project_rules", project_rules)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
     #
     # Statically prepare the rule logic. This takes the rules provided by the user and turns them into code.
     #
     return getattr(sys.modules["project_rules"], "RuleSet")()
+
+
+def main(argv=None):
+    """
+    Rules engine for SIP file generation.
+
+    Examples:
+
+        rules.py
+    """
+    if argv is None:
+        argv = sys.argv
+    parser = argparse.ArgumentParser(epilog=inspect.getdoc(main),
+                                     formatter_class=HelpFormatter)
+    parser.add_argument("-v", "--verbose", action="store_true", default=False, help=_("Enable verbose output"))
+    try:
+        args = parser.parse_args(argv[1:])
+        if args.verbose:
+            logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(name)s %(levelname)s: %(message)s')
+        else:
+            logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+        #
+        # Generate help!
+        #
+        for db in [RuleSet, ContainerRuleDb, ForwardDeclarationRuleDb, FunctionRuleDb, ParameterRuleDb, TypedefRuleDb,
+                   VariableRuleDb, MethodCodeDb, ModuleCodeDb]:
+            name = db.__name__
+            print(name)
+            print("=" * len(name))
+            print()
+            print(inspect.getdoc(db))
+            print()
+    except Exception as e:
+        tbk = traceback.format_exc()
+        print(tbk)
+        return -1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/find-modules/sip_generator.py
+++ b/find-modules/sip_generator.py
@@ -531,18 +531,19 @@ class SipGenerator(object):
         modifying_rule = self.rules.function_rules().apply(container, function, sip)
         pad = " " * (level * 4)
         if sip["name"]:
+            decl1 = ""
+            if modifying_rule:
+                decl1 += pad + "// Modified {} (by {}):\n".format(SipGenerator.describe(function), modifying_rule)
+            for modifying_rule in parameter_modifying_rules:
+                decl1 += pad + modifying_rule
+            decl = ""
             #
             # Any method-related code (%MethodCode, %VirtualCatcherCode, VirtualCallCode
             # or other method-related directives)?
             #
-            self.rules.methodcode(function, sip)
-            decl = ""
+            modifying_rule = self.rules.methodcode(function, sip)
             if modifying_rule:
-                decl += "// Modified {} (by {}):\n".format(SipGenerator.describe(function), modifying_rule) + pad
-            decl += pad.join(parameter_modifying_rules)
-            if parameter_modifying_rules:
-                decl += pad
-
+                decl1 += pad + "// Modified {} (by {}):\n".format(SipGenerator.describe(function), modifying_rule)
             decl += sip["name"] + "(" + ", ".join(sip["parameters"]) + ")"
             if sip["fn_result"]:
                 decl = sip["fn_result"] + " " + decl
@@ -551,6 +552,7 @@ class SipGenerator(object):
                 decl = pad + "template <" + ", ".join(sip["template_parameters"]) + ">\n" + decl
             decl += ";\n"
             decl += sip["code"]
+            decl = decl1 + decl
         else:
             decl = pad + "// Discarded {} (by {})\n".format(SipGenerator.describe(function), modifying_rule)
         return decl

--- a/tests/GenerateSipBindings/rules_SipTest.py
+++ b/tests/GenerateSipBindings/rules_SipTest.py
@@ -35,12 +35,10 @@ def methodGenerator(function, sip, entry):
 
 class RuleSet(Qt5Ruleset.RuleSet):
     def __init__(self):
-        Qt5Ruleset.RuleSet.__init__(self)
-        self._container_db = rules_engine.ContainerRuleDb(lambda: local_container_rules() + Qt5Ruleset.container_rules())
-        self._forward_declaration_db = rules_engine.ForwardDeclarationRuleDb(lambda: local_forward_declaration_rules() + Qt5Ruleset.forward_declaration_rules())
-        self._fn_db = rules_engine.FunctionRuleDb(lambda: local_function_rules() + Qt5Ruleset.function_rules())
-        self._typedef_db = rules_engine.TypedefRuleDb(lambda: local_typedef_rules() + Qt5Ruleset.typedef_rules())
-        self._modulecode = rules_engine.ModuleCodeDb({
+        super(RuleSet, self).__init__()
+        self.add_rules(container_rules=local_container_rules, forward_declaration_rules=local_forward_declaration_rules,
+                       function_rules=local_function_rules, typedef_rules=local_typedef_rules,
+                       modulecode=lambda : {
             "cpplib.h": {
             "code": """
 %ModuleCode
@@ -50,9 +48,8 @@ int myAcumulate(const QList<int> *list) {
 %End\n
             """
             }
-            })
-
-        self._methodcode = rules_engine.MethodCodeDb({
+            },
+                        methodcode=lambda : {
             "SomeNS": {
                 "customMethod": {
                     "code": """


### PR DESCRIPTION
The API to the rule database is now less abstract, and more opinionated
to reduce the amount of boilerplate rule writers need to use. The
explicit ability to add new rules reflects the model of having a core
set of rules plus multiple additional sets (e.g. one per framework).

The change also improves the way that rule-based diagnostic names
are generated to match the new structure, making the diagnostic
names reflect the use of the add_rules() mechanism.

A couple of minor changes introduce a pre-defined noop rule handler
so that added rules can be used to silently override previously added
rules, and restore a main function which emits online help on rule
database structure.